### PR TITLE
Add HRIM range visualization plugin

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,8 @@ find_package(rviz_visual_testing_framework REQUIRED)
 
 find_package(Qt5 REQUIRED COMPONENTS Widgets Test)
 
+find_package(geometry_msgs REQUIRED)
+find_package(std_msgs REQUIRED)
 find_package(hrim_geometry_msgs REQUIRED)
 find_package(pluginlib REQUIRED)
 find_package(rclcpp REQUIRED)
@@ -69,6 +71,7 @@ find_package(urdf REQUIRED)
 find_package(visualization_msgs REQUIRED)
 find_package(hrim_sensor_camera_msgs REQUIRED)
 find_package(hrim_sensor_imu_msgs REQUIRED)
+find_package(hrim_sensor_rangefinder_msgs REQUIRED)
 
 # These need to be added in the add_library() call so AUTOMOC detects them.
 set(rviz_hrim_plugins_headers_to_moc
@@ -76,6 +79,7 @@ set(rviz_hrim_plugins_headers_to_moc
   include/rviz_hrim_plugins/displays/camera/camera_display.hpp
   include/rviz_hrim_plugins/displays/imu/imu_visual.hpp
   include/rviz_hrim_plugins/displays/imu/imu_display.hpp
+  include/rviz_hrim_plugins/displays/range/range_display.hpp
 )
 
 set(rviz_hrim_plugins_source_files
@@ -84,6 +88,7 @@ set(rviz_hrim_plugins_source_files
   src/rviz_hrim_plugins/displays/camera/camera_display.cpp
   src/rviz_hrim_plugins/displays/imu/imu_visual.cpp
   src/rviz_hrim_plugins/displays/imu/imu_display.cpp
+  src/rviz_hrim_plugins/displays/range/range_display.cpp
 )
 
 add_library(rviz_hrim_plugins SHARED
@@ -104,6 +109,7 @@ target_include_directories(rviz_hrim_plugins PUBLIC
   ${visualization_msgs_INCLUDE_DIRS}
   ${hrim_sensor_camera_msgs_INCLUDE_DIRS}
   ${hrim_sensor_imu_msgs_INCLUDE_DIRS}
+  ${hrim_sensor_rangefinder_msgs_INCLUDE_DIRS}
 )
 
 target_link_libraries(rviz_hrim_plugins
@@ -124,6 +130,8 @@ ament_target_dependencies(rviz_hrim_plugins
   hrim_geometry_msgs
   hrim_sensor_camera_msgs
   hrim_sensor_imu_msgs
+  hrim_sensor_rangefinder_msgs
+  std_msgs
   rclcpp
   resource_retriever
   urdf

--- a/include/rviz_hrim_plugins/displays/range/range_display.hpp
+++ b/include/rviz_hrim_plugins/displays/range/range_display.hpp
@@ -27,16 +27,19 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef RVIZ_DEFAULT_PLUGINS__DISPLAYS__RANGE__RANGE_DISPLAY_HPP_
-#define RVIZ_DEFAULT_PLUGINS__DISPLAYS__RANGE__RANGE_DISPLAY_HPP_
+#ifndef RVIZ_HRIM_PLUGINS__DISPLAYS__RANGE__RANGE_DISPLAY_HPP_
+#define RVIZ_HRIM_PLUGINS__DISPLAYS__RANGE__RANGE_DISPLAY_HPP_
 
 #include <memory>
 #include <vector>
 
-#include "sensor_msgs/msg/range.hpp"
+#include <hrim_sensor_rangefinder_msgs/msg/distance.hpp>
+#include <hrim_sensor_rangefinder_msgs/msg/specs_rangefinder.hpp>
+
+#include "std_msgs/msg/header.hpp"
 
 #include "rviz_common/ros_topic_display.hpp"
-#include "rviz_default_plugins/visibility_control.hpp"
+#include "rviz_hrim_plugins/visibility_control.hpp"
 
 namespace rviz_rendering
 {
@@ -55,7 +58,7 @@ class IntProperty;
 }  // namespace rviz_common
 
 
-namespace rviz_default_plugins
+namespace rviz_hrim_plugins
 {
 namespace displays
 {
@@ -63,8 +66,8 @@ namespace displays
  * \class RangeDisplay
  * \brief Displays a sensor_msgs::Range message as a cone.
  */
-class RVIZ_DEFAULT_PLUGINS_PUBLIC RangeDisplay : public
-  rviz_common::RosTopicDisplay<sensor_msgs::msg::Range>
+class RVIZ_HRIM_PLUGINS_PUBLIC RangeDisplay : public
+    rviz_common::RosTopicDisplay<hrim_sensor_rangefinder_msgs::msg::Distance>
 {
   Q_OBJECT
 
@@ -79,7 +82,7 @@ public:
 
   void reset() override;
 
-  void processMessage(sensor_msgs::msg::Range::ConstSharedPtr msg) override;
+  void processMessage(hrim_sensor_rangefinder_msgs::msg::Distance::ConstSharedPtr msg) override;
 
 protected:
   void onInitialize() override;
@@ -89,7 +92,24 @@ private Q_SLOTS:
   void updateColorAndAlpha();
 
 private:
-  float getDisplayedRange(sensor_msgs::msg::Range::ConstSharedPtr msg);
+  void subscribe() override;
+
+  void unsubscribe() override;
+
+  void createSpecsSubscription();
+
+  rclcpp::Subscription<hrim_sensor_rangefinder_msgs::msg::SpecsRangefinder>::SharedPtr specs_sub_;
+
+  hrim_sensor_rangefinder_msgs::msg::SpecsRangefinder::ConstSharedPtr current_specs_;
+
+  std::mutex specs_mutex_;
+
+  bool new_specs_;
+
+  double range_fov_;
+
+  float getDisplayedRange(hrim_sensor_rangefinder_msgs::msg::Distance::ConstSharedPtr msg);
+
   geometry_msgs::msg::Pose getPose(float displayed_range);
 
   std::vector<std::shared_ptr<rviz_rendering::Shape>> cones_;
@@ -101,6 +121,6 @@ private:
 };
 
 }  // namespace displays
-}  // namespace rviz_default_plugins
+}  // namespace rviz_hrim_plugins
 
-#endif  // RVIZ_DEFAULT_PLUGINS__DISPLAYS__RANGE__RANGE_DISPLAY_HPP_
+#endif  // RVIZ_HRIM_PLUGINS__DISPLAYS__RANGE__RANGE_DISPLAY_HPP_

--- a/include/rviz_hrim_plugins/displays/range/range_display.hpp
+++ b/include/rviz_hrim_plugins/displays/range/range_display.hpp
@@ -1,0 +1,106 @@
+/*
+ * Copyright (c) 2008, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef RVIZ_DEFAULT_PLUGINS__DISPLAYS__RANGE__RANGE_DISPLAY_HPP_
+#define RVIZ_DEFAULT_PLUGINS__DISPLAYS__RANGE__RANGE_DISPLAY_HPP_
+
+#include <memory>
+#include <vector>
+
+#include "sensor_msgs/msg/range.hpp"
+
+#include "rviz_common/ros_topic_display.hpp"
+#include "rviz_default_plugins/visibility_control.hpp"
+
+namespace rviz_rendering
+{
+class Shape;
+}  // namespace rviz_rendering
+
+namespace rviz_common
+{
+class QueueSizeProperty;
+namespace properties
+{
+class ColorProperty;
+class FloatProperty;
+class IntProperty;
+}  // namespace properties
+}  // namespace rviz_common
+
+
+namespace rviz_default_plugins
+{
+namespace displays
+{
+/**
+ * \class RangeDisplay
+ * \brief Displays a sensor_msgs::Range message as a cone.
+ */
+class RVIZ_DEFAULT_PLUGINS_PUBLIC RangeDisplay : public
+  rviz_common::RosTopicDisplay<sensor_msgs::msg::Range>
+{
+  Q_OBJECT
+
+public:
+  // TODO(botteroa-si): Constructor for testing. Remove once ros nodes can be mocked and
+  // initialize() can be called
+  explicit RangeDisplay(rviz_common::DisplayContext * display_context);
+
+  RangeDisplay();
+
+  ~RangeDisplay() override;
+
+  void reset() override;
+
+  void processMessage(sensor_msgs::msg::Range::ConstSharedPtr msg) override;
+
+protected:
+  void onInitialize() override;
+
+private Q_SLOTS:
+  void updateBufferLength();
+  void updateColorAndAlpha();
+
+private:
+  float getDisplayedRange(sensor_msgs::msg::Range::ConstSharedPtr msg);
+  geometry_msgs::msg::Pose getPose(float displayed_range);
+
+  std::vector<std::shared_ptr<rviz_rendering::Shape>> cones_;
+
+  rviz_common::properties::ColorProperty * color_property_;
+  rviz_common::properties::FloatProperty * alpha_property_;
+  rviz_common::properties::IntProperty * buffer_length_property_;
+  std::unique_ptr<rviz_common::QueueSizeProperty> queue_size_property_;
+};
+
+}  // namespace displays
+}  // namespace rviz_default_plugins
+
+#endif  // RVIZ_DEFAULT_PLUGINS__DISPLAYS__RANGE__RANGE_DISPLAY_HPP_

--- a/plugins_description.xml
+++ b/plugins_description.xml
@@ -21,4 +21,14 @@
     </description>
     <message_type>hrim_sensor_imu_msgs/IMU</message_type>
   </class>
+  <class
+    name="rviz_hrim_plugins/Range"
+    type="rviz_hrim_plugins::displays::RangeDisplay"
+    base_class_type="rviz_common::Display">
+    <description>
+      Displays the data from hrim_sensor_rangefinder_msgs::msg::Distance messages as cones. &lt;a href="http://www.ros.org/wiki/rviz/DisplayTypes/Range"&gt;More Information&lt;/a&gt;
+    </description>
+    <message_type>hrim_sensor_rangefinder_msgs/Distance</message_type>
+    <message_type>hrim_sensor_rangefinder_msgs/SpecsRangefinder</message_type>
+  </class>
 </library>

--- a/src/rviz_hrim_plugins/displays/range/range_display.cpp
+++ b/src/rviz_hrim_plugins/displays/range/range_display.cpp
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2012, Willow Garage, Inc.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ *     * Redistributions of source code must retain the above copyright
+ *       notice, this list of conditions and the following disclaimer.
+ *     * Redistributions in binary form must reproduce the above copyright
+ *       notice, this list of conditions and the following disclaimer in the
+ *       documentation and/or other materials provided with the distribution.
+ *     * Neither the name of the Willow Garage, Inc. nor the names of its
+ *       contributors may be used to endorse or promote products derived from
+ *       this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "rviz_default_plugins/displays/range/range_display.hpp"
+
+#include <limits>
+#include <memory>
+
+#include "rviz_rendering/objects/shape.hpp"
+#include "rviz_common/properties/color_property.hpp"
+#include "rviz_common/properties/float_property.hpp"
+#include "rviz_common/properties/int_property.hpp"
+#include "rviz_common/properties/parse_color.hpp"
+#include "rviz_common/properties/queue_size_property.hpp"
+
+
+namespace rviz_default_plugins
+{
+namespace displays
+{
+
+RangeDisplay::RangeDisplay(rviz_common::DisplayContext * display_context)
+: RangeDisplay()
+{
+  context_ = display_context;
+  scene_manager_ = context_->getSceneManager();
+  scene_node_ = scene_manager_->getRootSceneNode()->createChildSceneNode();
+  updateBufferLength();
+}
+
+RangeDisplay::RangeDisplay()
+: queue_size_property_(std::make_unique<rviz_common::QueueSizeProperty>(this, 100))
+{
+  color_property_ = new rviz_common::properties::ColorProperty(
+    "Color", Qt::white,
+    "Color to draw the range.",
+    this, SLOT(updateColorAndAlpha()));
+
+  alpha_property_ = new rviz_common::properties::FloatProperty(
+    "Alpha", 0.5f,
+    "Amount of transparency to apply to the range.",
+    this, SLOT(updateColorAndAlpha()));
+
+  buffer_length_property_ = new rviz_common::properties::IntProperty(
+    "Buffer Length", 1,
+    "Number of prior measurements to display.",
+    this, SLOT(updateBufferLength()));
+  buffer_length_property_->setMin(1);
+}
+
+void RangeDisplay::onInitialize()
+{
+  RTDClass::onInitialize();
+  updateBufferLength();
+  updateColorAndAlpha();
+}
+
+RangeDisplay::~RangeDisplay() = default;
+
+void RangeDisplay::reset()
+{
+  RTDClass::reset();
+  updateBufferLength();
+}
+
+void RangeDisplay::updateColorAndAlpha()
+{
+  auto color = color_property_->getOgreColor();
+  float alpha = alpha_property_->getFloat();
+  for (const auto & cone : cones_) {
+    cone->setColor(color.r, color.g, color.b, alpha);
+  }
+  context_->queueRender();
+}
+
+void RangeDisplay::updateBufferLength()
+{
+  int buffer_length = buffer_length_property_->getInt();
+  auto color = color_property_->getOgreColor();
+  cones_.resize(buffer_length);
+
+  for (auto & cone : cones_) {
+    cone.reset(new rviz_rendering::Shape(
+        rviz_rendering::Shape::Cone, context_->getSceneManager(), scene_node_));
+
+    cone->setScale(Ogre::Vector3(0, 0, 0));
+    cone->setColor(color.r, color.g, color.b, 0);
+  }
+}
+
+void RangeDisplay::processMessage(const sensor_msgs::msg::Range::ConstSharedPtr msg)
+{
+  auto cone = cones_[messages_received_ % buffer_length_property_->getInt()];
+
+  Ogre::Vector3 position;
+  Ogre::Quaternion orientation;
+  float displayed_range = getDisplayedRange(msg);
+  auto pose = getPose(displayed_range);
+
+  if (!context_->getFrameManager()->transform(
+      msg->header.frame_id, msg->header.stamp, pose, position, orientation))
+  {
+    setMissingTransformToFixedFrame(msg->header.frame_id);
+    return;
+  }
+  setTransformOk();
+
+  cone->setPosition(position);
+  cone->setOrientation(orientation);
+
+  float cone_width = 2.0f * displayed_range * tan(msg->field_of_view / 2.0f);
+  Ogre::Vector3 scale(cone_width, displayed_range, cone_width);
+  cone->setScale(scale);
+
+  auto color = color_property_->getOgreColor();
+  cone->setColor(color.r, color.g, color.b, alpha_property_->getFloat());
+}
+
+float RangeDisplay::getDisplayedRange(sensor_msgs::msg::Range::ConstSharedPtr msg)
+{
+  float displayed_range = 0.0f;
+  if (msg->min_range <= msg->range && msg->range <= msg->max_range) {
+    displayed_range = msg->range;
+  } else if (msg->min_range == msg->max_range) {  // Fixed distance ranger
+    // NaNs and +Inf return false here: both of those should have 0.0 as the range
+    if (msg->range < 0 && !std::isfinite(msg->range)) {
+      displayed_range = msg->min_range;  // -Inf, display the detectable range
+    }
+  }
+  return displayed_range;
+}
+
+geometry_msgs::msg::Pose RangeDisplay::getPose(float displayed_range)
+{
+  float fudge_factor = 0.008824f;  // fudge factor measured, must be inaccuracy of cone model.
+  geometry_msgs::msg::Pose pose;
+
+  pose.position.x = displayed_range / 2 - fudge_factor * displayed_range;
+  pose.orientation.z = 0.707f;
+  pose.orientation.w = 0.707f;
+
+  return pose;
+}
+
+}  // namespace displays
+}  // namespace rviz_default_plugins
+
+#include <pluginlib/class_list_macros.hpp>  // NOLINT
+PLUGINLIB_EXPORT_CLASS(rviz_default_plugins::displays::RangeDisplay, rviz_common::Display)


### PR DESCRIPTION
Visualizes the range data from an `hrim_sensor_rangefinder_msgs/msg/Distance` message.

Topic name for `SpecsRangefinder` (necessary for `field_of_view`) is hardcoded to `/ray/specs`.